### PR TITLE
Centering with Markdown and reference-style links

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,22 +9,24 @@
     <img src="https://github.com/pizzaboxer/bloxstrap/raw/main/Images/Bloxstrap-full-light.png#gh-light-mode-only" width="420">
 </p>
 
-<p align="center">
-    <a href="https://github.com/pizzaboxer/bloxstrap/blob/main/LICENSE"><img src="https://img.shields.io/github/license/pizzaboxer/bloxstrap" alt="License"></a>
-    <a href="https://github.com/pizzaboxer/bloxstrap/actions"><img src="https://img.shields.io/github/actions/workflow/status/pizzaboxer/bloxstrap/ci.yml?branch=main&label=builds" alt="GitHub Workflow Status"></a>
-    <a href="https://crowdin.com/project/bloxstrap"><img src="https://badges.crowdin.net/bloxstrap/localized.svg" alt="Crowdin"></a>
-    <a href="https://github.com/pizzaboxer/bloxstrap/releases"><img src="https://img.shields.io/github/downloads/pizzaboxer/bloxstrap/latest/total?color=981bfe" alt="Downloads"></a>
-    <a href="https://github.com/pizzaboxer/bloxstrap/releases/latest"><img src="https://img.shields.io/github/v/release/pizzaboxer/bloxstrap?color=7a39fb" alt="Version"></a>
-    <a href="https://discord.gg/nKjV3mGq6R"><img src="https://img.shields.io/discord/1099468797410283540?logo=discord&logoColor=white&label=discord&color=4d3dff" alt="Discord"></a>
-    <a href="https://media.tenor.com/FIkSGbGycmAAAAAd/manly-roblox.gif"><img src="https://img.shields.io/badge/mom%20made-pizza%20rolls-orange" alt="lol"></a>
-</p>
+<div align="center">
+
+[![License][shield-repo-license]][repo-license]
+[![GitHub Workflow Status][shield-repo-workflow]][repo-actions]
+[![Crowdin][shield-crowdin-status]][crowdin-project]
+[![Downloads][shield-repo-releases]][repo-releases]
+[![Version][shield-repo-latest]][repo-latest]
+[![Discord][shield-discord-server]][discord-invite]
+[![lol][shield-tenor-meme]][tenor-gif]
+
+</div>
 
 ----
 
 Bloxstrap is a third-party replacement for the standard Roblox bootstrapper, providing additional useful features and improvements.
 
 Running into a problem or need help with something? [Check out the Wiki](https://github.com/pizzaboxer/bloxstrap/wiki). If you can't find anything, or would like to suggest something, please [submit an issue](https://github.com/pizzaboxer/bloxstrap/issues).
- 
+
 Bloxstrap is only supported for PCs running Windows.
 
 ## Frequently Asked Questions
@@ -47,8 +49,8 @@ Bloxstrap is only supported for PCs running Windows.
 - Simple support for modding of content files for customizability (death sound, mouse cursor, etc)
 - See where your server is geographically located (courtesy of [ipinfo.io](https://ipinfo.io))
 - Ability to configure graphics fidelity and UI experience
- 
- ## Installing
+
+## Installing
 Download the [latest release of Bloxstrap](https://github.com/pizzaboxer/bloxstrap/releases/latest), and run it. Configure your preferences if needed, and install. That's about it!
 
 Alternatively, you can install Bloxstrap via [Winget](https://winstall.app/apps/pizzaboxer.Bloxstrap) by running this in a Command Prompt window:
@@ -65,3 +67,22 @@ Once installed, Bloxstrap is added to your Start Menu, where you can access the 
 ## Code
 
 Bloxstrap uses the [WPF UI](https://github.com/lepoco/wpfui) library for the user interface design. We currently use and maintain our own fork of WPF UI at [bloxstraplabs/wpfui](https://github.com/bloxstraplabs/wpfui).
+
+
+[shield-repo-license]:  https://img.shields.io/github/license/pizzaboxer/bloxstrap
+[shield-repo-workflow]: https://img.shields.io/github/actions/workflow/status/pizzaboxer/bloxstrap/ci.yml?branch=main&label=builds
+[shield-repo-releases]: https://img.shields.io/github/downloads/pizzaboxer/bloxstrap/latest/total?color=981bfe
+[shield-repo-latest]:   https://img.shields.io/github/v/release/pizzaboxer/bloxstrap?color=7a39fb
+
+[shield-crowdin-status]: https://badges.crowdin.net/bloxstrap/localized.svg
+[shield-discord-server]: https://img.shields.io/discord/1099468797410283540?logo=discord&logoColor=white&label=discord&color=4d3dff
+[shield-tenor-meme]:     https://img.shields.io/badge/mom_made-pizza_rolls-orange
+
+[repo-license]:  https://github.com/pizzaboxer/bloxstrap/blob/main/LICENSE
+[repo-actions]:  https://github.com/pizzaboxer/bloxstrap/actions
+[repo-releases]: https://github.com/pizzaboxer/bloxstrap/releases
+[repo-latest]:   https://github.com/pizzaboxer/bloxstrap/releases/latest
+
+[crowdin-project]: https://crowdin.com/project/bloxstrap
+[discord-invite]:  https://discord.gg/nKjV3mGq6R
+[tenor-gif]:       https://media.tenor.com/FIkSGbGycmAAAAAd/manly-roblox.gif


### PR DESCRIPTION
# Why?
There is a better way to do centering with Markdown without replacing it with HTML as in commit 8ffb22c.

<details><summary>Explanation (skip if you're a highly trained professional 😎)</summary>

## Explanation
- You can center Markdown elements by surrounding them with `div` element:
```md
<div align="center">

![License](https://img.shields.io/github/license/pizzaboxer/bloxstrap)

</div>
```

<div align="center">

![License](https://img.shields.io/github/license/pizzaboxer/bloxstrap)

</div>

> **IMPORTANT:** Notice how HTML tags and Markdown element are separated from each other with newlines.

- You can use [reference-style links][1] that make it easier to read and edit the file:
```md
- You can use [reference-style links][1] that make it easier to read and edit the file:

[1]: <https://www.markdownguide.org/basic-syntax/#reference-style-links> "Hey, I'm a reference-style link!"
```

- And it works for images, too:
```md
![License][2]

[2]: https://img.shields.io/github/license/pizzaboxer/bloxstrap
```

![License][2]

[1]: <https://www.markdownguide.org/basic-syntax/#reference-style-links> "Hey, I'm a reference-style link!"

- A combination of these tricks gives you a good centered badge.
```md
<div align="center">

[![License][2]][3]

</div>

[2]: https://img.shields.io/github/license/pizzaboxer/bloxstrap
[3]: <https://github.com/pizzaboxer/bloxstrap/blob/main/LICENSE> "MIT License"
```

<div align="center">

[![License][2]][3]

</div>

- It allows you to add more badges:
```md
<div align="center">

[![License][2]][3]
[![Downloads][4]][5]

</div>

[2]: https://img.shields.io/github/license/pizzaboxer/bloxstrap
[3]: <https://github.com/pizzaboxer/bloxstrap/blob/main/LICENSE> "MIT License"
[4]: https://img.shields.io/github/downloads/pizzaboxer/bloxstrap/latest/total?color=981bfe
[5]: <https://github.com/pizzaboxer/bloxstrap/releases> "Downloads"
```

<div align="center">

[![License][2]][3]
[![Downloads][4]][5]

</div>

> **IMPORTANT:** Badges do not appear inlined in pull requests and issues, but they are inlined in `README.md`.

[2]: https://img.shields.io/github/license/pizzaboxer/bloxstrap
[3]: <https://github.com/pizzaboxer/bloxstrap/blob/main/LICENSE> "MIT License"
[4]: https://img.shields.io/github/downloads/pizzaboxer/bloxstrap/latest/total?color=981bfe
[5]: <https://github.com/pizzaboxer/bloxstrap/releases> "Downloads"

</details>

## Changes
- Usage of `<div align="center">` to center Markdown elements
- Usage of reference-style links for better reading and editing
- As a side-effect of using Visual Studio Code, sneaky whitespaces were removed

---

I am open for discussion and doing requested changes.