### PR TITLE
fix: include unfinished locales in QA builds

### DIFF
--- a/Bloxstrap/Locale.cs
+++ b/Bloxstrap/Locale.cs
@@ -24,7 +24,7 @@ namespace Bloxstrap
 #endif
             { "de", "Deutsch" },
 #if QA_BUILD
-            // { "dk", "Dansk" },
+            { "dk", "Dansk" },
 #endif
             { "es-ES", "Español" },
 #if QA_BUILD

--- a/Bloxstrap/Locale.cs
+++ b/Bloxstrap/Locale.cs
@@ -20,7 +20,7 @@ namespace Bloxstrap
             { "bn", "বাংলা" },
             { "bs", "Bosanski" },
 #if QA_BUILD
-            // { "cs", "Čeština" },
+            { "cs", "Čeština" },
 #endif
             { "de", "Deutsch" },
 #if QA_BUILD


### PR DESCRIPTION
If this is intentional — why is it commented out?