### PR TITLE
Add redist.zip to common extract roots

### DIFF
--- a/Bloxstrap/AppData/CommonAppData.cs
+++ b/Bloxstrap/AppData/CommonAppData.cs
@@ -13,6 +13,7 @@ namespace Bloxstrap.AppData
         private IReadOnlyDictionary<string, string> _commonMap { get; } = new Dictionary<string, string>()
         {
             { "Libraries.zip",                 @"" },
+            { "redist.zip",                    @"" },
             { "shaders.zip",                   @"shaders\" },
             { "ssl.zip",                       @"ssl\" },
 

--- a/Bloxstrap/AppData/RobloxStudioData.cs
+++ b/Bloxstrap/AppData/RobloxStudioData.cs
@@ -19,7 +19,6 @@
         public override IReadOnlyDictionary<string, string> PackageDirectoryMap { get; set; } = new Dictionary<string, string>()
         {
             { "RobloxStudio.zip",                @"" },
-            { "redist.zip",                      @"" },
             { "LibrariesQt5.zip",                @"" },
 
             { "content-studio_svg_textures.zip", @"content\studio_svg_textures\"},


### PR DESCRIPTION
It looks like v647 and beyond is including `redist.zip` in Player manifests, just like WindowsStudio64, though I'm not sure if this will cause issues with Bloxstrap tomorrow if it's not added.

<https://setup.rbxcdn.com/version-9dbf9780562444e1-rbxPkgManifest.txt>
![image](https://github.com/user-attachments/assets/6331df16-83ab-440e-a0d4-160fa57c2d81)

Just had to add it to RDD as well, though ignoring it also doesn't currently affect anything if one already has VS redist stuff already installed globally.
![image](https://github.com/user-attachments/assets/6545ce67-d69c-47b1-80d7-27aa76c2e497)