### PR TITLE
Add Bloxstrap version to bug report Issue Form template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -30,6 +30,14 @@ body:
         - label: I am using the latest version of Bloxstrap.
           required: true
         - label: I did not answer truthfully to all the above checkboxes.
+  - type: input
+    id: version
+    attributes:
+      label: Bloxstrap Version
+      description: "What version of Bloxstrap are you using?"
+      placeholder: "v1.0.0"
+    validations:
+      required: true
   - type: textarea
     id: what-happened
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -34,7 +34,7 @@ body:
     id: version
     attributes:
       label: Bloxstrap Version
-      description: "What version of Bloxstrap are you using?"
+      description: "What version of Bloxstrap are you using? Find it in the 'About' section of the Settings"
       placeholder: "v1.0.0"
     validations:
       required: true


### PR DESCRIPTION
Adds an input field to the `bug_report.yaml` file for Issue Form templates for the Bloxstrap version. The goal of this PR is to better reduce issues and identify issues related to outdated versions of Bloxstrap.

![Frame 2](https://github.com/user-attachments/assets/0c977795-6c05-422b-98be-eab519642018)

This might be irrelevant due to the **Preliminary instructions**, but a number of users still ignore such instructions and create an issue. Adding to the fact they might not be aware of not using the latest version or don't know the latest version of Bloxstrap is.

A Bloxstrap version field also adds the ability to use a GitHub Action to auto-respond to issues that have an outdated Bloxstrap version in the version field, either commenting that the version is outdated or closing the issue.