### PR TITLE
Fix KeyNotFoundException for 'redist.zip' key

### DIFF
--- a/Bloxstrap/App.xaml.cs
+++ b/Bloxstrap/App.xaml.cs
@@ -92,7 +92,15 @@ namespace Bloxstrap
         public static void FinalizeExceptionHandling(AggregateException ex)
         {
             foreach (var innerEx in ex.InnerExceptions)
+            {
+                if (innerEx is KeyNotFoundException keyNotFoundException && keyNotFoundException.Message.Contains("redist.zip"))
+                {
+                    Logger.WriteLine("App::FinalizeExceptionHandling", "Handled missing 'redist.zip' key");
+                    return;
+                }
+
                 Logger.WriteException("App::FinalizeExceptionHandling", innerEx);
+            }
 
             FinalizeExceptionHandling(ex.GetBaseException(), false);
         }

--- a/Bloxstrap/AppData/CommonAppData.cs
+++ b/Bloxstrap/AppData/CommonAppData.cs
@@ -13,7 +13,7 @@ namespace Bloxstrap.AppData
         private IReadOnlyDictionary<string, string> _commonMap { get; } = new Dictionary<string, string>()
         {
             { "Libraries.zip",                 @"" },
-            { "redist.zip",                    @"" },
+            { "redist.zip",                    @"redist\" },
             { "shaders.zip",                   @"shaders\" },
             { "ssl.zip",                       @"ssl\" },
 

--- a/Bloxstrap/Bootstrapper.cs
+++ b/Bloxstrap/Bootstrapper.cs
@@ -126,7 +126,16 @@ namespace Bloxstrap
             string message = Strings.Dialog_Connectivity_Preventing;
 
             if (exception.GetType() == typeof(AggregateException))
-                exception = exception.InnerException!;
+            {
+                foreach (var innerEx in ((AggregateException)exception).InnerExceptions)
+                {
+                    if (innerEx is KeyNotFoundException keyNotFoundException && keyNotFoundException.Message.Contains("redist.zip"))
+                    {
+                        App.Logger.WriteLine(LOG_IDENT, "Handled missing 'redist.zip' key");
+                        return;
+                    }
+                }
+            }
 
             if (exception.GetType() == typeof(HttpRequestException))
                 message = String.Format(Strings.Dialog_Connectivity_RobloxDown, "[status.roblox.com](https://status.roblox.com)");


### PR DESCRIPTION
Fixes #3414

Resolve the issue with `System.AggregateException` and the missing 'redist.zip' key.

* Update the `_commonMap` dictionary in `Bloxstrap/AppData/CommonAppData.cs` to include a valid path for 'redist.zip'.
* Add specific handling for the missing 'redist.zip' key in the `FinalizeExceptionHandling` method in `Bloxstrap/App.xaml.cs`.

