### PR TITLE
[Custom bootstrappers] Add {Version} string template

### DIFF
--- a/Bloxstrap/UI/Elements/Bootstrapper/CustomDialog.Creator.cs
+++ b/Bloxstrap/UI/Elements/Bootstrapper/CustomDialog.Creator.cs
@@ -233,12 +233,12 @@ namespace Bloxstrap.UI.Elements.Bootstrapper
 
         private static string? GetTranslatedText(string? text)
         {
+            if (text != null) text = text.Replace("{Version}", App.Version);
+
             if (text == null || !text.StartsWith('{') || !text.EndsWith('}'))
                 return text; // can't be translated (not in the correct format)
 
             string resourceName = text[1..^1];
-            if (resourceName == "Version")
-                return App.Version;
             return Strings.ResourceManager.GetStringSafe(resourceName);
         }
 

--- a/Bloxstrap/UI/Elements/Bootstrapper/CustomDialog.Creator.cs
+++ b/Bloxstrap/UI/Elements/Bootstrapper/CustomDialog.Creator.cs
@@ -1,4 +1,4 @@
-﻿using System.Windows;
+using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Data;
@@ -237,6 +237,8 @@ namespace Bloxstrap.UI.Elements.Bootstrapper
                 return text; // can't be translated (not in the correct format)
 
             string resourceName = text[1..^1];
+            if (resourceName == "Version")
+                return App.Version;
             return Strings.ResourceManager.GetStringSafe(resourceName);
         }
 


### PR DESCRIPTION
Replaces `{Version}` in TextBlocks with Bloxstrap's version in custom bootstrappers for further customizability™

![Bloxstrap_4vygw9WFJs](https://github.com/user-attachments/assets/40f9af97-b269-4563-a695-79c3844e6bb8)
![Bloxstrap_E7mWncG7Va](https://github.com/user-attachments/assets/137cd19d-e081-4f1a-aa60-83cd00571008)