### PR TITLE
Add steps to reproduce to bug report form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -46,6 +46,16 @@ body:
     validations:
       required: true
   - type: textarea
+    id: repro-steps
+    attributes:
+      label: How do you reproduce the problem?
+      description: Include the steps to reproduce the problem from start to finish. Include details such as FastFlags you added and settings you changed.
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. Scroll down to '...'
+        4. See error
+  - type: textarea
     id: log
     attributes:
       label: Bloxstrap Log


### PR DESCRIPTION
Adds an optional text area to the bug report for steps to reproduce the bug. Most bug reports only include the error and could be proven more useful if they included steps for developers to be able to reproduce.

* If you plan to debug as a developer, it is most logical to have those steps to reproduce the bug and developers may be forced to ask for that information later in the issue comments
* If you are reporting a bug, you want to include how to reproduce the bug for reasons above instead of only an error