### PR TITLE
Update Winget Releaser action

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -8,7 +8,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: vedantmgoyal2009/winget-releaser@v2
+      - uses: vedantmgoyal9/winget-releaser@main
         with:
           identifier: pizzaboxer.Bloxstrap
           token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
Update `vedantmgoyal2009/winget-releaser@v2` -> `vedantmgoyal9/winget-releaser@main`. `v2` has been outdated for a long time now (also fixed the non-existent URL from the latest release in https://github.com/microsoft/winget-pkgs/pull/204420)