### PR TITLE
Upgrade .NET version from .NET 6 to .NET 8

### DIFF
--- a/Bloxstrap/Bloxstrap.csproj
+++ b/Bloxstrap/Bloxstrap.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>True</UseWindowsForms>


### PR DESCRIPTION
Upgrades the Bloxstrap .NET version from .NET 6.0 to .NET 8.0, because of .NET 6 reaching EOL.