### PR TITLE
Target a Windows SDK to allow for usage of WinRT APIs

### DIFF
--- a/.github/workflows/ci-debug.yml
+++ b/.github/workflows/ci-debug.yml
@@ -27,4 +27,4 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: Bloxstrap (Debug) (${{ github.sha }})
-        path: .\Bloxstrap\bin\Debug\net6.0-windows\win-x64\publish\*
+        path: .\Bloxstrap\bin\Debug\net6.0-windows10.0.17763.0\win-x64\publish\*

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -31,7 +31,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: Bloxstrap (Release) (${{ github.sha }})
-        path: .\Bloxstrap\bin\Release\net6.0-windows\win-x64\publish\*
+        path: .\Bloxstrap\bin\Release\net6.0-windows10.0.17763.0\win-x64\publish\*
 
   release:
     needs: build

--- a/Bloxstrap/Bloxstrap.csproj
+++ b/Bloxstrap/Bloxstrap.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows10.0.17763.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>True</UseWindowsForms>


### PR DESCRIPTION
This changes the project's target framework from net6.0 to net6.0-windows10.0.17763.0, which targets Windows 10 (1809). This allows for the usage of APIs introduced with WinRT.