### PR TITLE
Ask for permission to update Bloxstrap on metered connections

### DIFF
--- a/Bloxstrap/Bootstrapper.cs
+++ b/Bloxstrap/Bootstrapper.cs
@@ -18,6 +18,7 @@ using System.Windows.Forms;
 using System.Windows.Shell;
 
 using Microsoft.Win32;
+using Windows.Networking.Connectivity;
 
 using Bloxstrap.AppData;
 using Bloxstrap.RobloxInterfaces;
@@ -577,6 +578,24 @@ namespace Bloxstrap
 #else
             string version = App.Version;
 #endif
+
+            // check if we are on a metered connection, as updating Bloxstrap might incur additional costs
+            var profile = NetworkInformation.GetInternetConnectionProfile();
+            bool meteredConnection = (profile != null) && (profile.GetConnectionCost().NetworkCostType != NetworkCostType.Unrestricted);
+
+            if (meteredConnection)
+            {
+                App.Logger.WriteLine(LOG_IDENT, "Metered connection detected");
+
+                var result = Frontend.ShowMessageBox(
+                    Strings.Bootstrapper_AutoUpdateMetered,
+                    MessageBoxImage.Exclamation,
+                    MessageBoxButton.YesNo
+                );
+
+                if (result != MessageBoxResult.Yes)
+                    return false;
+            }
 
             SetStatus(Strings.Bootstrapper_Status_UpgradingBloxstrap);
 

--- a/Bloxstrap/Resources/Strings.Designer.cs
+++ b/Bloxstrap/Resources/Strings.Designer.cs
@@ -161,6 +161,15 @@ namespace Bloxstrap.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to An update for Bloxstrap is available, but it has been detected you are currently using a metered connection. Would you like to update now?.
+        /// </summary>
+        public static string Bootstrapper_AutoUpdateMetered {
+            get {
+                return ResourceManager.GetString("Bootstrapper.AutoUpdateMetered", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Roblox is currently running, and launching another instance will close it. Are you sure you want to continue launching?.
         /// </summary>
         public static string Bootstrapper_ConfirmLaunch {

--- a/Bloxstrap/Resources/Strings.resx
+++ b/Bloxstrap/Resources/Strings.resx
@@ -1267,4 +1267,7 @@ Please close any applications that may be using Roblox's files, and relaunch.</v
     <value>All Bloxstrap logs</value>
     <comment>Label that appears next to a checkbox</comment>
   </data>
+  <data name="Bootstrapper.AutoUpdateMetered" xml:space="preserve">
+    <value>An update for Bloxstrap is available, but it has been detected you are currently using a metered connection. Would you like to update now?</value>
+  </data>
 </root>


### PR DESCRIPTION
This makes it so that, if it's detected that a user is currently using a metered connection (such as cellular data), Bloxstrap will prompt for whether the user wants to update the bootstrapper or not.

Requires WinRT APIs (#4249)