### PR TITLE
Automatically switch theme on system theme change

### DIFF
--- a/Bloxstrap/Extensions/ThemeEx.cs
+++ b/Bloxstrap/Extensions/ThemeEx.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Win32;
+﻿using Windows.UI.ViewManagement;
 
 namespace Bloxstrap.Extensions
 {
@@ -9,9 +9,9 @@ namespace Bloxstrap.Extensions
             if (dialogTheme != Theme.Default)
                 return dialogTheme;
 
-            using var key = Registry.CurrentUser.OpenSubKey("SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize");
-
-            if (key?.GetValue("AppsUseLightTheme") is int value && value == 0)
+            var settings = new UISettings();
+            var background = settings.GetColorValue(UIColorType.Background);
+            if (((5 * background.G) + (2 * background.R) + background.B) < (8 * 128))
                 return Theme.Dark;
 
             return Theme.Light;

--- a/Bloxstrap/UI/Elements/Base/WpfUiWindow.cs
+++ b/Bloxstrap/UI/Elements/Base/WpfUiWindow.cs
@@ -4,23 +4,27 @@ using Wpf.Ui.Appearance;
 using Wpf.Ui.Controls;
 using Wpf.Ui.Mvvm.Contracts;
 using Wpf.Ui.Mvvm.Services;
+using Windows.UI.ViewManagement;
 
 namespace Bloxstrap.UI.Elements.Base
 {
     public abstract class WpfUiWindow : UiWindow
     {
         private readonly IThemeService _themeService = new ThemeService();
+        private UISettings _settings;
 
         public WpfUiWindow()
         {
             ApplyTheme();
+            _settings = new UISettings();
+            _settings.ColorValuesChanged += ColorValuesChanged;
         }
 
         public void ApplyTheme()
         {
             _themeService.SetTheme(App.Settings.Prop.Theme.GetFinal() == Enums.Theme.Dark ? ThemeType.Dark : ThemeType.Light);
             _themeService.SetSystemAccent();
-
+            
 #if QA_BUILD
             this.BorderBrush = System.Windows.Media.Brushes.Red;
             this.BorderThickness = new Thickness(4);
@@ -36,6 +40,14 @@ namespace Bloxstrap.UI.Elements.Base
             }
 
             base.OnSourceInitialized(e);
+        }
+
+        private async void ColorValuesChanged(UISettings sender, object args)
+        {
+            await Dispatcher.InvokeAsync(() =>
+            {
+                ApplyTheme();
+            });
         }
     }
 }

--- a/Bloxstrap/UI/Elements/ContextMenu/ServerHistory.xaml
+++ b/Bloxstrap/UI/Elements/ContextMenu/ServerHistory.xaml
@@ -18,6 +18,7 @@
         Height="420"
         Background="{ui:ThemeResource ApplicationBackgroundBrush}"
         ExtendsContentIntoTitleBar="True"
+        WindowBackdropType="Mica"
         WindowStartupLocation="CenterScreen">
     <Grid>
         <Grid.RowDefinitions>

--- a/Bloxstrap/UI/Elements/ContextMenu/ServerInformation.xaml
+++ b/Bloxstrap/UI/Elements/ContextMenu/ServerInformation.xaml
@@ -18,6 +18,7 @@
         ResizeMode="NoResize"
         Background="{ui:ThemeResource ApplicationBackgroundBrush}"
         ExtendsContentIntoTitleBar="True"
+        WindowBackdropType="Mica"
         WindowStartupLocation="CenterScreen">
     <Grid>
         <Grid.RowDefinitions>

--- a/Bloxstrap/UI/Elements/Dialogs/AddFastFlagDialog.xaml
+++ b/Bloxstrap/UI/Elements/Dialogs/AddFastFlagDialog.xaml
@@ -16,6 +16,7 @@
         ResizeMode="NoResize"
         Background="{ui:ThemeResource ApplicationBackgroundBrush}"
         ExtendsContentIntoTitleBar="True"
+        WindowBackdropType="Mica"
         WindowStartupLocation="CenterScreen">
     <ui:UiWindow.Resources>
         <converters:RangeConverter x:Key="ValidationConverter" From="0" />

--- a/Bloxstrap/UI/Elements/Dialogs/ConnectivityDialog.xaml
+++ b/Bloxstrap/UI/Elements/Dialogs/ConnectivityDialog.xaml
@@ -15,6 +15,7 @@
         Title="{x:Static resources:Strings.Dialog_Connectivity_Title}"
         Background="{ui:ThemeResource ApplicationBackgroundBrush}"
         ExtendsContentIntoTitleBar="True"
+        WindowBackdropType="Mica"
         WindowStartupLocation="CenterScreen">
     <Grid>
         <Grid.RowDefinitions>

--- a/Bloxstrap/UI/Elements/Dialogs/ExceptionDialog.xaml
+++ b/Bloxstrap/UI/Elements/Dialogs/ExceptionDialog.xaml
@@ -16,6 +16,7 @@
         SizeToContent="Height"
         Background="{ui:ThemeResource ApplicationBackgroundBrush}"
         ExtendsContentIntoTitleBar="True"
+        WindowBackdropType="Mica"
         WindowStartupLocation="CenterScreen">
     <Grid>
         <Grid.RowDefinitions>

--- a/Bloxstrap/UI/Elements/Dialogs/FluentMessageBox.xaml
+++ b/Bloxstrap/UI/Elements/Dialogs/FluentMessageBox.xaml
@@ -18,6 +18,7 @@
         ResizeMode="NoResize"
         Background="{ui:ThemeResource ApplicationBackgroundBrush}"
         ExtendsContentIntoTitleBar="True"
+        WindowBackdropType="Mica"
         WindowStartupLocation="CenterScreen">
     <Grid>
         <Grid.RowDefinitions>

--- a/Bloxstrap/UI/Elements/Dialogs/LanguageSelectorDialog.xaml
+++ b/Bloxstrap/UI/Elements/Dialogs/LanguageSelectorDialog.xaml
@@ -16,6 +16,7 @@
         ResizeMode="NoResize"
         Background="{ui:ThemeResource ApplicationBackgroundBrush}"
         ExtendsContentIntoTitleBar="True"
+        WindowBackdropType="Mica"
         WindowStartupLocation="CenterScreen">
     <Grid>
         <Grid.RowDefinitions>

--- a/Bloxstrap/UI/Elements/Dialogs/LaunchMenuDialog.xaml
+++ b/Bloxstrap/UI/Elements/Dialogs/LaunchMenuDialog.xaml
@@ -17,6 +17,7 @@
         ResizeMode="NoResize"
         Background="{ui:ThemeResource ApplicationBackgroundBrush}"
         ExtendsContentIntoTitleBar="True"
+        WindowBackdropType="Mica"
         WindowStartupLocation="CenterScreen">
     <Grid>
         <Grid.RowDefinitions>

--- a/Bloxstrap/UI/Elements/Dialogs/UninstallerDialog.xaml
+++ b/Bloxstrap/UI/Elements/Dialogs/UninstallerDialog.xaml
@@ -19,6 +19,7 @@
         ResizeMode="NoResize"
         Background="{ui:ThemeResource ApplicationBackgroundBrush}"
         ExtendsContentIntoTitleBar="True"
+        WindowBackdropType="Mica"
         WindowStartupLocation="CenterScreen">
     <Grid>
         <Grid.RowDefinitions>


### PR DESCRIPTION
This makes it so that when the system's theme changes and Bloxstrap is set to use the system color scheme, then it will update the colors on the fly.

https://github.com/user-attachments/assets/49d51bea-aece-4063-8a3f-c95ea62b9092

Requires WinRT APIs (#4249)