### PR TITLE
removed unnecessary stuff RobloxPlayerData.cs

### DIFF
--- a/Bloxstrap/AppData/RobloxPlayerData.cs
+++ b/Bloxstrap/AppData/RobloxPlayerData.cs
@@ -1,8 +1,4 @@
-﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Bloxstrap.AppData
 {
@@ -18,9 +14,9 @@ namespace Bloxstrap.AppData
 
         public override AppState State => App.RobloxState.Prop.Player;
 
-        public override IReadOnlyDictionary<string, string> PackageDirectoryMap { get; set; } = new Dictionary<string, string>()
+        public override IReadOnlyDictionary<string, string> PackageDirectoryMap { get; } = new Dictionary<string, string>
         {
-            { "RobloxApp.zip", @"" }
+            { "RobloxApp.zip", string.Empty }
         };
     }
 }


### PR DESCRIPTION
removed unnecessary using directives (System.Linq, System.Text, System.Threading.Tasks), changed the initialization of PackageDirectoryMap to use string.Empty instead of @"" for clarity, removed the set accessor from PackageDirectoryMap to make it read-only, as it is initialized directly.