### PR TITLE
Use `TaskbarProgress` to update taskbar for WPF dialogs

### DIFF
--- a/Bloxstrap/App.xaml.cs
+++ b/Bloxstrap/App.xaml.cs
@@ -30,6 +30,8 @@ namespace Bloxstrap
         // simple shorthand for extremely frequently used and long string - this goes under HKCU
         public const string UninstallKey = $@"Software\Microsoft\Windows\CurrentVersion\Uninstall\{ProjectName}";
 
+        public const int TaskbarProgressMaximum = 100;
+
         public static LaunchSettings LaunchSettings { get; private set; } = null!;
 
         public static BuildMetadataAttribute BuildMetadata = Assembly.GetExecutingAssembly().GetCustomAttribute<BuildMetadataAttribute>()!;

--- a/Bloxstrap/Bootstrapper.cs
+++ b/Bloxstrap/Bootstrapper.cs
@@ -32,9 +32,6 @@ namespace Bloxstrap
         #region Properties
         private const int ProgressBarMaximum = 10000;
 
-        private const double TaskbarProgressMaximumWpf = 1; // this can not be changed. keep it at 1.
-        private const int TaskbarProgressMaximumWinForms = WinFormsDialogBase.TaskbarProgressMaximum;
-
         private const string AppSettings =
             "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" +
             "<Settings>\r\n" +
@@ -57,7 +54,6 @@ namespace Bloxstrap
         private bool _isInstalling = false;
         private double _progressIncrement;
         private double _taskbarProgressIncrement;
-        private double _taskbarProgressMaximum;
         private long _totalDownloadedBytes = 0;
         private bool _packageExtractionSuccess = true;
 
@@ -130,7 +126,7 @@ namespace Bloxstrap
 
             // taskbar progress
             double taskbarProgressValue = _taskbarProgressIncrement * _totalDownloadedBytes;
-            taskbarProgressValue = Math.Clamp(taskbarProgressValue, 0, _taskbarProgressMaximum);
+            taskbarProgressValue = Math.Clamp(taskbarProgressValue, 0, App.TaskbarProgressMaximum);
 
             Dialog.TaskbarProgressValue = taskbarProgressValue;
         }
@@ -995,12 +991,7 @@ namespace Bloxstrap
                 int totalPackedSize = _versionPackageManifest.Sum(package => package.PackedSize);
                 _progressIncrement = (double)ProgressBarMaximum / totalPackedSize;
 
-                if (Dialog is WinFormsDialogBase)
-                    _taskbarProgressMaximum = (double)TaskbarProgressMaximumWinForms;
-                else
-                    _taskbarProgressMaximum = (double)TaskbarProgressMaximumWpf;
-
-                _taskbarProgressIncrement = _taskbarProgressMaximum / (double)totalPackedSize;
+                _taskbarProgressIncrement = App.TaskbarProgressMaximum / (double)totalPackedSize;
             }
 
             var extractionTasks = new List<Task>();

--- a/Bloxstrap/UI/Elements/Bootstrapper/Base/WinFormsDialogBase.cs
+++ b/Bloxstrap/UI/Elements/Bootstrapper/Base/WinFormsDialogBase.cs
@@ -7,8 +7,6 @@ namespace Bloxstrap.UI.Elements.Bootstrapper.Base
 {
     public class WinFormsDialogBase : Form, IBootstrapperDialog
     {
-        public const int TaskbarProgressMaximum = 100;
-
         public Bloxstrap.Bootstrapper? Bootstrapper { get; set; }
 
         private bool _isClosing;
@@ -76,7 +74,7 @@ namespace Bloxstrap.UI.Elements.Bootstrapper.Base
             set
             {
                 _taskbarProgressState = value;
-                TaskbarProgress.SetProgressState(Process.GetCurrentProcess().MainWindowHandle, value);
+                TaskbarProgress.SetProgressState(value);
             }
         }
 
@@ -86,7 +84,7 @@ namespace Bloxstrap.UI.Elements.Bootstrapper.Base
             set
             {
                 _taskbarProgressValue = value;
-                TaskbarProgress.SetProgressValue(Process.GetCurrentProcess().MainWindowHandle, (int)value, TaskbarProgressMaximum);
+                TaskbarProgress.SetProgressValue((int)value, App.TaskbarProgressMaximum);
             }
         }
 
@@ -132,6 +130,10 @@ namespace Bloxstrap.UI.Elements.Bootstrapper.Base
 
         public void Dialog_FormClosing(object sender, FormClosingEventArgs e)
         {
+            // reset taskbar progress status
+            TaskbarProgress.SetProgressState(TaskbarItemProgressState.None);
+            TaskbarProgress.SetProgressValue(0, 0);
+
             if (!_isClosing)
                 Bootstrapper?.Cancel();
         }

--- a/Bloxstrap/UI/Elements/Bootstrapper/Base/WpfDialogBase.cs
+++ b/Bloxstrap/UI/Elements/Bootstrapper/Base/WpfDialogBase.cs
@@ -1,0 +1,127 @@
+﻿using Bloxstrap.UI.Utility;
+using Bloxstrap.UI.ViewModels.Bootstrapper;
+using System.Windows;
+using System.Windows.Forms;
+using System.Windows.Shell;
+using System.Windows.Threading;
+
+namespace Bloxstrap.UI.Elements.Bootstrapper.Base
+{
+    public class WpfDialogBase : Window, IBootstrapperDialog
+    {
+        // Should hopefully be set by the other ctor
+        protected BootstrapperDialogViewModel _viewModel = null!;
+
+        public Bloxstrap.Bootstrapper? Bootstrapper { get; set; }
+
+        private bool _isClosing;
+
+        #region UI Elements
+        public virtual string Message
+        {
+            get => _viewModel.Message;
+            set
+            {
+                _viewModel.Message = value;
+                _viewModel.OnPropertyChanged(nameof(_viewModel.Message));
+            }
+        }
+
+        public virtual ProgressBarStyle ProgressStyle
+        {
+            get => _viewModel.ProgressIndeterminate ? ProgressBarStyle.Marquee : ProgressBarStyle.Continuous;
+            set
+            {
+                _viewModel.ProgressIndeterminate = (value == ProgressBarStyle.Marquee);
+                _viewModel.OnPropertyChanged(nameof(_viewModel.ProgressIndeterminate));
+            }
+        }
+
+        public virtual int ProgressMaximum
+        {
+            get => _viewModel.ProgressMaximum;
+            set
+            {
+                _viewModel.ProgressMaximum = value;
+                _viewModel.OnPropertyChanged(nameof(_viewModel.ProgressMaximum));
+            }
+        }
+
+        public virtual int ProgressValue
+        {
+            get => _viewModel.ProgressValue;
+            set
+            {
+                _viewModel.ProgressValue = value;
+                _viewModel.OnPropertyChanged(nameof(_viewModel.ProgressValue));
+            }
+        }
+
+        public virtual TaskbarItemProgressState TaskbarProgressState
+        {
+            get => _viewModel.TaskbarProgressState;
+            set
+            {
+                _viewModel.TaskbarProgressState = value;
+                TaskbarProgress.SetProgressState(value);
+                _viewModel.OnPropertyChanged(nameof(_viewModel.TaskbarProgressState));
+            }
+        }
+
+        public virtual double TaskbarProgressValue
+        {
+            get => _viewModel.TaskbarProgressValue;
+            set
+            {
+                _viewModel.TaskbarProgressValue = value;
+                TaskbarProgress.SetProgressValue((int)value, App.TaskbarProgressMaximum);
+                _viewModel.OnPropertyChanged(nameof(_viewModel.TaskbarProgressValue));
+            }
+        }
+
+        public virtual bool CancelEnabled
+        {
+            get => _viewModel.CancelEnabled;
+            set
+            {
+                _viewModel.CancelEnabled = value;
+
+                _viewModel.OnPropertyChanged(nameof(_viewModel.CancelButtonVisibility));
+                _viewModel.OnPropertyChanged(nameof(_viewModel.CancelEnabled));
+            }
+        }
+        #endregion
+
+        protected WpfDialogBase()
+        {
+            Title = App.Settings.Prop.BootstrapperTitle;
+            Icon = App.Settings.Prop.BootstrapperIcon.GetIcon().GetImageSource();
+        }
+
+        #region IBootstrapperDialog Methods
+        public void ShowBootstrapper() => this.ShowDialog();
+
+        public void CloseBootstrapper()
+        {
+            _isClosing = true;
+            Dispatcher.BeginInvoke(this.Close);
+        }
+
+        public void ShowSuccess(string message, Action? callback) => BaseFunctions.ShowSuccess(message, callback);
+        #endregion
+
+        #region Overrides
+        protected override void OnClosed(EventArgs e)
+        {
+            // reset taskbar progress status
+            TaskbarProgress.SetProgressState(TaskbarItemProgressState.None);
+            TaskbarProgress.SetProgressValue(0, 0);
+
+            if (!_isClosing)
+                Bootstrapper?.Cancel();
+
+            base.OnClosed(e);
+        }
+        #endregion
+    }
+}

--- a/Bloxstrap/UI/Elements/Bootstrapper/Base/WpfUiDialogBase.cs
+++ b/Bloxstrap/UI/Elements/Bootstrapper/Base/WpfUiDialogBase.cs
@@ -1,0 +1,127 @@
+﻿using Bloxstrap.UI.Elements.Base;
+using Bloxstrap.UI.Utility;
+using Bloxstrap.UI.ViewModels.Bootstrapper;
+using System.ComponentModel;
+using System.Windows.Forms;
+using System.Windows.Shell;
+
+namespace Bloxstrap.UI.Elements.Bootstrapper.Base
+{
+    public class WpfUiDialogBase : WpfUiWindow, IBootstrapperDialog
+    {
+        // Should hopefully be set by the other ctor
+        protected BootstrapperDialogViewModel _viewModel = null!;
+
+        public Bloxstrap.Bootstrapper? Bootstrapper { get; set; }
+
+        private bool _isClosing;
+
+        #region UI Elements
+        public virtual string Message
+        {
+            get => _viewModel.Message;
+            set
+            {
+                _viewModel.Message = value;
+                _viewModel.OnPropertyChanged(nameof(_viewModel.Message));
+            }
+        }
+
+        public virtual ProgressBarStyle ProgressStyle
+        {
+            get => _viewModel.ProgressIndeterminate ? ProgressBarStyle.Marquee : ProgressBarStyle.Continuous;
+            set
+            {
+                _viewModel.ProgressIndeterminate = (value == ProgressBarStyle.Marquee);
+                _viewModel.OnPropertyChanged(nameof(_viewModel.ProgressIndeterminate));
+            }
+        }
+
+        public virtual int ProgressMaximum
+        {
+            get => _viewModel.ProgressMaximum;
+            set
+            {
+                _viewModel.ProgressMaximum = value;
+                _viewModel.OnPropertyChanged(nameof(_viewModel.ProgressMaximum));
+            }
+        }
+
+        public virtual int ProgressValue
+        {
+            get => _viewModel.ProgressValue;
+            set
+            {
+                _viewModel.ProgressValue = value;
+                _viewModel.OnPropertyChanged(nameof(_viewModel.ProgressValue));
+            }
+        }
+
+        public virtual TaskbarItemProgressState TaskbarProgressState
+        {
+            get => _viewModel.TaskbarProgressState;
+            set
+            {
+                _viewModel.TaskbarProgressState = value;
+                TaskbarProgress.SetProgressState(value);
+                _viewModel.OnPropertyChanged(nameof(_viewModel.TaskbarProgressState));
+            }
+        }
+
+        public virtual double TaskbarProgressValue
+        {
+            get => _viewModel.TaskbarProgressValue;
+            set
+            {
+                _viewModel.TaskbarProgressValue = value;
+                TaskbarProgress.SetProgressValue((int)value, App.TaskbarProgressMaximum);
+                _viewModel.OnPropertyChanged(nameof(_viewModel.TaskbarProgressValue));
+            }
+        }
+
+        public virtual bool CancelEnabled
+        {
+            get => _viewModel.CancelEnabled;
+            set
+            {
+                _viewModel.CancelEnabled = value;
+
+                _viewModel.OnPropertyChanged(nameof(_viewModel.CancelButtonVisibility));
+                _viewModel.OnPropertyChanged(nameof(_viewModel.CancelEnabled));
+            }
+        }
+        #endregion
+
+        protected WpfUiDialogBase()
+        {
+            Title = App.Settings.Prop.BootstrapperTitle;
+            Icon = App.Settings.Prop.BootstrapperIcon.GetIcon().GetImageSource();
+        }
+
+        #region IBootstrapperDialog Methods
+        public void ShowBootstrapper() => this.ShowDialog();
+
+        public void CloseBootstrapper()
+        {
+            _isClosing = true;
+            Dispatcher.BeginInvoke(this.Close);
+        }
+
+        public void ShowSuccess(string message, Action? callback) => BaseFunctions.ShowSuccess(message, callback);
+        #endregion
+
+        #region Overrides
+        protected override void OnClosed(EventArgs e)
+        {
+            // reset taskbar progress status
+            TaskbarProgress.SetProgressState(TaskbarItemProgressState.None);
+            TaskbarProgress.SetProgressValue(0, 0);
+
+            if (!_isClosing)
+                Bootstrapper?.Cancel();
+
+            base.OnClosed(e);
+        }
+        #endregion
+    }
+}

--- a/Bloxstrap/UI/Elements/Bootstrapper/ByfronDialog.xaml
+++ b/Bloxstrap/UI/Elements/Bootstrapper/ByfronDialog.xaml
@@ -1,5 +1,6 @@
-﻿<Window x:Class="Bloxstrap.UI.Elements.Bootstrapper.ByfronDialog"
+﻿<base:WpfDialogBase x:Class="Bloxstrap.UI.Elements.Bootstrapper.ByfronDialog"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:base="clr-namespace:Bloxstrap.UI.Elements.Bootstrapper.Base"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -10,12 +11,7 @@
         WindowStyle="None"
         WindowStartupLocation="CenterScreen"
         AllowsTransparency="True"
-        Background="Transparent"
-        Closing="Window_Closing">
-
-    <Window.TaskbarItemInfo>
-        <TaskbarItemInfo ProgressState="{Binding Path=TaskbarProgressState}" ProgressValue="{Binding Path=TaskbarProgressValue}" />
-    </Window.TaskbarItemInfo>
+        Background="Transparent">
 
     <Border CornerRadius="10" BorderBrush="#33393B3D" Background="{Binding Background}" BorderThickness="{Binding DialogBorder}">
         <Grid>
@@ -47,4 +43,4 @@
             </Grid>
         </Grid>
     </Border>
-</Window>
+</base:WpfDialogBase>

--- a/Bloxstrap/UI/Elements/Bootstrapper/ByfronDialog.xaml.cs
+++ b/Bloxstrap/UI/Elements/Bootstrapper/ByfronDialog.xaml.cs
@@ -1,11 +1,7 @@
 ﻿using System.Windows;
-using System.ComponentModel;
-using System.Windows.Forms;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
-using System.Windows.Shell;
 
-using Bloxstrap.UI.Elements.Bootstrapper.Base;
 using Bloxstrap.UI.ViewModels.Bootstrapper;
 
 namespace Bloxstrap.UI.Elements.Bootstrapper
@@ -13,16 +9,10 @@ namespace Bloxstrap.UI.Elements.Bootstrapper
     /// <summary>
     /// Interaction logic for ByfronDialog.xaml
     /// </summary>
-    public partial class ByfronDialog : IBootstrapperDialog
+    public partial class ByfronDialog
     {
-        private readonly ByfronDialogViewModel _viewModel;
-
-        public Bloxstrap.Bootstrapper? Bootstrapper { get; set; }
-
-        private bool _isClosing;
-
         #region UI Elements
-        public string Message
+        public override string Message
         {
             get => _viewModel.Message;
             set
@@ -36,57 +26,7 @@ namespace Bloxstrap.UI.Elements.Bootstrapper
             }
         }
 
-        public ProgressBarStyle ProgressStyle
-        {
-            get => _viewModel.ProgressIndeterminate ? ProgressBarStyle.Marquee : ProgressBarStyle.Continuous;
-            set
-            {
-                _viewModel.ProgressIndeterminate = (value == ProgressBarStyle.Marquee);
-                _viewModel.OnPropertyChanged(nameof(_viewModel.ProgressIndeterminate));
-            }
-        }
-
-        public int ProgressMaximum
-        {
-            get => _viewModel.ProgressMaximum;
-            set
-            {
-                _viewModel.ProgressMaximum = value;
-                _viewModel.OnPropertyChanged(nameof(_viewModel.ProgressMaximum));
-            }
-        }
-
-        public int ProgressValue
-        {
-            get => _viewModel.ProgressValue;
-            set
-            {
-                _viewModel.ProgressValue = value;
-                _viewModel.OnPropertyChanged(nameof(_viewModel.ProgressValue));
-            }
-        }
-
-        public TaskbarItemProgressState TaskbarProgressState
-        {
-            get => _viewModel.TaskbarProgressState;
-            set
-            {
-                _viewModel.TaskbarProgressState = value;
-                _viewModel.OnPropertyChanged(nameof(_viewModel.TaskbarProgressState));
-            }
-        }
-
-        public double TaskbarProgressValue
-        {
-            get => _viewModel.TaskbarProgressValue;
-            set
-            {
-                _viewModel.TaskbarProgressValue = value;
-                _viewModel.OnPropertyChanged(nameof(_viewModel.TaskbarProgressValue));
-            }
-        }
-
-        public bool CancelEnabled
+        public override bool CancelEnabled
         {
             get => _viewModel.CancelEnabled;
             set
@@ -95,51 +35,33 @@ namespace Bloxstrap.UI.Elements.Bootstrapper
 
                 _viewModel.OnPropertyChanged(nameof(_viewModel.CancelEnabled));
                 _viewModel.OnPropertyChanged(nameof(_viewModel.CancelButtonVisibility));
-                
-                _viewModel.OnPropertyChanged(nameof(_viewModel.VersionTextVisibility));
-                _viewModel.OnPropertyChanged(nameof(_viewModel.VersionText));
+
+                _viewModel.OnPropertyChanged(nameof(ByfronDialogViewModel.VersionTextVisibility));
+                _viewModel.OnPropertyChanged(nameof(ByfronDialogViewModel.VersionText));
             }
         }
         #endregion
 
         public ByfronDialog()
+            : base()
         {
             string version = Utilities.GetRobloxVersionStr(Bootstrapper?.IsStudioLaunch ?? false);
-            _viewModel = new ByfronDialogViewModel(this, version);
-            DataContext = _viewModel;
-            Title = App.Settings.Prop.BootstrapperTitle;
-            Icon = App.Settings.Prop.BootstrapperIcon.GetIcon().GetImageSource();
+            ByfronDialogViewModel viewModel = new ByfronDialogViewModel(this, version);
+            _viewModel = viewModel;
+            DataContext = viewModel;
 
             if (App.Settings.Prop.Theme.GetFinal() == Theme.Light)
             {
                 // Matching the roblox website light theme as close as possible.
-                _viewModel.DialogBorder = new Thickness(1);
-                _viewModel.Background = new SolidColorBrush(Color.FromRgb(242, 244, 245));
-                _viewModel.Foreground = new SolidColorBrush(Color.FromRgb(57, 59, 61));
-                _viewModel.IconColor = new SolidColorBrush(Color.FromRgb(57, 59, 61));
-                _viewModel.ProgressBarBackground = new SolidColorBrush(Color.FromRgb(189, 190, 190));
-                _viewModel.ByfronLogoLocation = new BitmapImage(new Uri("pack://application:,,,/Resources/BootstrapperStyles/ByfronDialog/ByfronLogoLight.jpg"));
+                viewModel.DialogBorder = new Thickness(1);
+                viewModel.Background = new SolidColorBrush(Color.FromRgb(242, 244, 245));
+                viewModel.Foreground = new SolidColorBrush(Color.FromRgb(57, 59, 61));
+                viewModel.IconColor = new SolidColorBrush(Color.FromRgb(57, 59, 61));
+                viewModel.ProgressBarBackground = new SolidColorBrush(Color.FromRgb(189, 190, 190));
+                viewModel.ByfronLogoLocation = new BitmapImage(new Uri("pack://application:,,,/Resources/BootstrapperStyles/ByfronDialog/ByfronLogoLight.jpg"));
             }
 
             InitializeComponent();
         }
-        private void Window_Closing(object sender, CancelEventArgs e)
-        {
-            if (!_isClosing)
-                Bootstrapper?.Cancel();
-        }
-
-        #region IBootstrapperDialog Methods
-        // Referencing FluentDialog
-        public void ShowBootstrapper() => this.ShowDialog();
-
-        public void CloseBootstrapper()
-        {
-            _isClosing = true;
-            Dispatcher.BeginInvoke(this.Close);
-        }
-
-        public void ShowSuccess(string message, Action? callback) => BaseFunctions.ShowSuccess(message, callback);
-        #endregion
     }
 }

--- a/Bloxstrap/UI/Elements/Bootstrapper/ClassicFluentDialog.xaml
+++ b/Bloxstrap/UI/Elements/Bootstrapper/ClassicFluentDialog.xaml
@@ -1,8 +1,8 @@
-﻿<base:WpfUiWindow
+﻿<base:WpfUiDialogBase
     x:Class="Bloxstrap.UI.Elements.Bootstrapper.ClassicFluentDialog"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:base="clr-namespace:Bloxstrap.UI.Elements.Base"
+    xmlns:base="clr-namespace:Bloxstrap.UI.Elements.Bootstrapper.Base"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:resources="clr-namespace:Bloxstrap.Resources"
@@ -12,16 +12,11 @@
     Height="190"
     MinHeight="0"
     Background="{ui:ThemeResource ApplicationBackgroundBrush}"
-    Closing="UiWindow_Closing"
     ExtendsContentIntoTitleBar="True"
     ResizeMode="NoResize"
     WindowBackdropType="Mica"
     WindowStartupLocation="CenterScreen"
     mc:Ignorable="d">
-
-    <Window.TaskbarItemInfo>
-        <TaskbarItemInfo ProgressState="{Binding Path=TaskbarProgressState}" ProgressValue="{Binding Path=TaskbarProgressValue}" />
-    </Window.TaskbarItemInfo>
 
     <Grid>
         <Grid.RowDefinitions>
@@ -59,4 +54,4 @@
             <Button Margin="0" Content="{x:Static resources:Strings.Common_Cancel}" Width="120" HorizontalAlignment="Right" IsEnabled="{Binding CancelEnabled, Mode=OneWay}" Command="{Binding CancelInstallCommand}" />
         </Border>
     </Grid>
-</base:WpfUiWindow>
+</base:WpfUiDialogBase>

--- a/Bloxstrap/UI/Elements/Bootstrapper/ClassicFluentDialog.xaml.cs
+++ b/Bloxstrap/UI/Elements/Bootstrapper/ClassicFluentDialog.xaml.cs
@@ -1,123 +1,19 @@
-﻿using System.ComponentModel;
-using System.Windows.Forms;
-using System.Windows.Shell;
-
-using Bloxstrap.UI.ViewModels.Bootstrapper;
-using Bloxstrap.UI.Elements.Bootstrapper.Base;
+﻿using Bloxstrap.UI.ViewModels.Bootstrapper;
 
 namespace Bloxstrap.UI.Elements.Bootstrapper
 {
     /// <summary>
     /// Interaction logic for ClassicFluentDialog.xaml
     /// </summary>
-    public partial class ClassicFluentDialog : IBootstrapperDialog
+    public partial class ClassicFluentDialog
     {
-        private readonly BootstrapperDialogViewModel _viewModel;
-
-        public Bloxstrap.Bootstrapper? Bootstrapper { get; set; }
-
-        private bool _isClosing;
-
-        #region UI Elements
-        public string Message
-        {
-            get => _viewModel.Message;
-            set
-            {
-                _viewModel.Message = value;
-                _viewModel.OnPropertyChanged(nameof(_viewModel.Message));
-            }
-        }
-
-        public ProgressBarStyle ProgressStyle
-        {
-            get => _viewModel.ProgressIndeterminate ? ProgressBarStyle.Marquee : ProgressBarStyle.Continuous;
-            set
-            {
-                _viewModel.ProgressIndeterminate = (value == ProgressBarStyle.Marquee);
-                _viewModel.OnPropertyChanged(nameof(_viewModel.ProgressIndeterminate));
-            }
-        }
-
-        public int ProgressMaximum
-        {
-            get => _viewModel.ProgressMaximum;
-            set
-            {
-                _viewModel.ProgressMaximum = value;
-                _viewModel.OnPropertyChanged(nameof(_viewModel.ProgressMaximum));
-            }
-        }
-
-        public int ProgressValue
-        {
-            get => _viewModel.ProgressValue;
-            set
-            {
-                _viewModel.ProgressValue = value;
-                _viewModel.OnPropertyChanged(nameof(_viewModel.ProgressValue));
-            }
-        }
-
-        public TaskbarItemProgressState TaskbarProgressState
-        {
-            get => _viewModel.TaskbarProgressState;
-            set
-            {
-                _viewModel.TaskbarProgressState = value;
-                _viewModel.OnPropertyChanged(nameof(_viewModel.TaskbarProgressState));
-            }
-        }
-
-        public double TaskbarProgressValue
-        {
-            get => _viewModel.TaskbarProgressValue;
-            set
-            {
-                _viewModel.TaskbarProgressValue = value;
-                _viewModel.OnPropertyChanged(nameof(_viewModel.TaskbarProgressValue));
-            }
-        }
-
-        public bool CancelEnabled
-        {
-            get => _viewModel.CancelEnabled;
-            set
-            {
-                _viewModel.CancelEnabled = value;
-
-                _viewModel.OnPropertyChanged(nameof(_viewModel.CancelButtonVisibility));
-                _viewModel.OnPropertyChanged(nameof(_viewModel.CancelEnabled));
-            }
-        }
-        #endregion
-
         public ClassicFluentDialog()
+            : base()
         {
             InitializeComponent();
 
             _viewModel = new ClassicFluentDialogViewModel(this);
             DataContext = _viewModel;
-            Title = App.Settings.Prop.BootstrapperTitle;
-            Icon = App.Settings.Prop.BootstrapperIcon.GetIcon().GetImageSource();
         }
-
-        private void UiWindow_Closing(object sender, CancelEventArgs e)
-        {
-            if (!_isClosing)
-                Bootstrapper?.Cancel();
-        }
-
-        #region IBootstrapperDialog Methods
-        public void ShowBootstrapper() => this.ShowDialog();
-
-        public void CloseBootstrapper()
-        {
-            _isClosing = true;
-            Dispatcher.BeginInvoke(this.Close);
-        }
-
-        public void ShowSuccess(string message, Action? callback) => BaseFunctions.ShowSuccess(message, callback);
-        #endregion
     }
 }

--- a/Bloxstrap/UI/Elements/Bootstrapper/CustomDialog.xaml
+++ b/Bloxstrap/UI/Elements/Bootstrapper/CustomDialog.xaml
@@ -1,8 +1,8 @@
-﻿<base:WpfUiWindow
+﻿<base:WpfUiDialogBase
     x:Class="Bloxstrap.UI.Elements.Bootstrapper.CustomDialog"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:base="clr-namespace:Bloxstrap.UI.Elements.Base"
+    xmlns:base="clr-namespace:Bloxstrap.UI.Elements.Bootstrapper.Base"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="clr-namespace:Bloxstrap.UI.Elements.Bootstrapper"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -20,9 +20,6 @@
     WindowBackdropType="Disable"
     WindowStartupLocation="CenterScreen"
     mc:Ignorable="d">
-    <Window.TaskbarItemInfo>
-        <TaskbarItemInfo ProgressState="{Binding Path=TaskbarProgressState}" ProgressValue="{Binding Path=TaskbarProgressValue}" />
-    </Window.TaskbarItemInfo>
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
@@ -52,4 +49,4 @@
             <Grid x:Name="ElementGrid" Grid.Row="1" />
         </Grid>
     </Grid>
-</base:WpfUiWindow>
+</base:WpfUiDialogBase>

--- a/Bloxstrap/UI/Elements/Bootstrapper/CustomDialog.xaml.cs
+++ b/Bloxstrap/UI/Elements/Bootstrapper/CustomDialog.xaml.cs
@@ -1,122 +1,19 @@
-﻿using Bloxstrap.UI.Elements.Bootstrapper.Base;
-using Bloxstrap.UI.ViewModels.Bootstrapper;
-using System.ComponentModel;
-using System.Windows.Forms;
-using System.Windows.Shell;
+﻿using Bloxstrap.UI.ViewModels.Bootstrapper;
 
 namespace Bloxstrap.UI.Elements.Bootstrapper
 {
     /// <summary>
     /// Interaction logic for CustomDialog.xaml
     /// </summary>
-    public partial class CustomDialog : IBootstrapperDialog
+    public partial class CustomDialog
     {
-        private readonly BootstrapperDialogViewModel _viewModel;
-
-        public Bloxstrap.Bootstrapper? Bootstrapper { get; set; }
-
-        private bool _isClosing;
-
-        #region UI Elements
-        public string Message
-        {
-            get => _viewModel.Message;
-            set
-            {
-                _viewModel.Message = value;
-                _viewModel.OnPropertyChanged(nameof(_viewModel.Message));
-            }
-        }
-
-        public ProgressBarStyle ProgressStyle
-        {
-            get => _viewModel.ProgressIndeterminate ? ProgressBarStyle.Marquee : ProgressBarStyle.Continuous;
-            set
-            {
-                _viewModel.ProgressIndeterminate = (value == ProgressBarStyle.Marquee);
-                _viewModel.OnPropertyChanged(nameof(_viewModel.ProgressIndeterminate));
-            }
-        }
-
-        public int ProgressMaximum
-        {
-            get => _viewModel.ProgressMaximum;
-            set
-            {
-                _viewModel.ProgressMaximum = value;
-                _viewModel.OnPropertyChanged(nameof(_viewModel.ProgressMaximum));
-            }
-        }
-
-        public int ProgressValue
-        {
-            get => _viewModel.ProgressValue;
-            set
-            {
-                _viewModel.ProgressValue = value;
-                _viewModel.OnPropertyChanged(nameof(_viewModel.ProgressValue));
-            }
-        }
-
-        public TaskbarItemProgressState TaskbarProgressState
-        {
-            get => _viewModel.TaskbarProgressState;
-            set
-            {
-                _viewModel.TaskbarProgressState = value;
-                _viewModel.OnPropertyChanged(nameof(_viewModel.TaskbarProgressState));
-            }
-        }
-
-        public double TaskbarProgressValue
-        {
-            get => _viewModel.TaskbarProgressValue;
-            set
-            {
-                _viewModel.TaskbarProgressValue = value;
-                _viewModel.OnPropertyChanged(nameof(_viewModel.TaskbarProgressValue));
-            }
-        }
-
-        public bool CancelEnabled
-        {
-            get => _viewModel.CancelEnabled;
-            set
-            {
-                _viewModel.CancelEnabled = value;
-
-                _viewModel.OnPropertyChanged(nameof(_viewModel.CancelButtonVisibility));
-                _viewModel.OnPropertyChanged(nameof(_viewModel.CancelEnabled));
-            }
-        }
-        #endregion
-
         public CustomDialog()
+            : base()
         {
             InitializeComponent();
 
             _viewModel = new BootstrapperDialogViewModel(this);
             DataContext = _viewModel;
-            Title = App.Settings.Prop.BootstrapperTitle;
-            Icon = App.Settings.Prop.BootstrapperIcon.GetIcon().GetImageSource();
         }
-
-        private void UiWindow_Closing(object sender, CancelEventArgs e)
-        {
-            if (!_isClosing)
-                Bootstrapper?.Cancel();
-        }
-
-        #region IBootstrapperDialog Methods
-        public void ShowBootstrapper() => this.ShowDialog();
-
-        public void CloseBootstrapper()
-        {
-            _isClosing = true;
-            Dispatcher.BeginInvoke(this.Close);
-        }
-
-        public void ShowSuccess(string message, Action? callback) => BaseFunctions.ShowSuccess(message, callback);
-        #endregion
     }
 }

--- a/Bloxstrap/UI/Elements/Bootstrapper/FluentDialog.xaml
+++ b/Bloxstrap/UI/Elements/Bootstrapper/FluentDialog.xaml
@@ -1,8 +1,8 @@
-﻿<base:WpfUiWindow
+﻿<base:WpfUiDialogBase
     x:Class="Bloxstrap.UI.Elements.Bootstrapper.FluentDialog"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:base="clr-namespace:Bloxstrap.UI.Elements.Base"
+    xmlns:base="clr-namespace:Bloxstrap.UI.Elements.Bootstrapper.Base"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:resources="clr-namespace:Bloxstrap.Resources"
@@ -14,17 +14,12 @@
     d:DataContext="{d:DesignInstance vms:FluentDialogViewModel,
                                      IsDesignTimeCreatable=True}"
     Background="{ui:ThemeResource ApplicationBackgroundBrush}"
-    Closing="UiWindow_Closing"
     ExtendsContentIntoTitleBar="True"
     ResizeMode="NoResize"
     WindowBackdropType="{Binding Path=WindowBackdropType, Mode=OneTime}"
     WindowStartupLocation="CenterScreen"
     WindowStyle="None"
     mc:Ignorable="d">
-
-    <Window.TaskbarItemInfo>
-        <TaskbarItemInfo ProgressState="{Binding Path=TaskbarProgressState}" ProgressValue="{Binding Path=TaskbarProgressValue}" />
-    </Window.TaskbarItemInfo>
 
     <!--  Background is for Aero theme only  -->
     <Grid Background="{Binding Path=BackgroundColourBrush, Mode=OneTime}">
@@ -81,4 +76,4 @@
                 IsEnabled="{Binding CancelEnabled, Mode=OneWay}" />
         </Grid>
     </Grid>
-</base:WpfUiWindow>
+</base:WpfUiDialogBase>

--- a/Bloxstrap/UI/Elements/Bootstrapper/FluentDialog.xaml.cs
+++ b/Bloxstrap/UI/Elements/Bootstrapper/FluentDialog.xaml.cs
@@ -1,141 +1,23 @@
-﻿using Bloxstrap.UI.Elements.Bootstrapper.Base;
-using Bloxstrap.UI.ViewModels.Bootstrapper;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Forms;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Shapes;
-using System.Windows.Shell;
-using System.Windows.Threading;
+﻿using Bloxstrap.UI.ViewModels.Bootstrapper;
 
 namespace Bloxstrap.UI.Elements.Bootstrapper
 {
     /// <summary>
     /// Interaction logic for FluentDialog.xaml
     /// </summary>
-    public partial class FluentDialog : IBootstrapperDialog
+    public partial class FluentDialog
     {
-        private readonly FluentDialogViewModel _viewModel;
-
-        public Bloxstrap.Bootstrapper? Bootstrapper { get; set; }
-
-        private bool _isClosing;
-
-        #region UI Elements
-        public string Message
-        {
-            get => _viewModel.Message;
-            set
-            {
-                _viewModel.Message = value;
-                _viewModel.OnPropertyChanged(nameof(_viewModel.Message));
-            }
-        }
-
-        public ProgressBarStyle ProgressStyle
-        {
-            get => _viewModel.ProgressIndeterminate ? ProgressBarStyle.Marquee : ProgressBarStyle.Continuous;
-            set
-            {
-                _viewModel.ProgressIndeterminate = (value == ProgressBarStyle.Marquee);
-                _viewModel.OnPropertyChanged(nameof(_viewModel.ProgressIndeterminate));
-            }
-        }
-
-        public int ProgressMaximum
-        {
-            get => _viewModel.ProgressMaximum;
-            set
-            {
-                _viewModel.ProgressMaximum = value;
-                _viewModel.OnPropertyChanged(nameof(_viewModel.ProgressMaximum));
-            }
-        }
-
-        public int ProgressValue
-        {
-            get => _viewModel.ProgressValue;
-            set
-            {
-                _viewModel.ProgressValue = value;
-                _viewModel.OnPropertyChanged(nameof(_viewModel.ProgressValue));
-            }
-        }
-
-        public TaskbarItemProgressState TaskbarProgressState
-        {
-            get => _viewModel.TaskbarProgressState;
-            set
-            {
-                _viewModel.TaskbarProgressState = value;
-                _viewModel.OnPropertyChanged(nameof(_viewModel.TaskbarProgressState));
-            }
-        }
-
-        public double TaskbarProgressValue
-        {
-            get => _viewModel.TaskbarProgressValue;
-            set
-            {
-                _viewModel.TaskbarProgressValue = value;
-                _viewModel.OnPropertyChanged(nameof(_viewModel.TaskbarProgressValue));
-            }
-        }
-
-        public bool CancelEnabled
-        {
-            get => _viewModel.CancelEnabled;
-            set
-            {
-                _viewModel.CancelEnabled = value;
-
-                _viewModel.OnPropertyChanged(nameof(_viewModel.CancelButtonVisibility));
-                _viewModel.OnPropertyChanged(nameof(_viewModel.CancelEnabled));
-            }
-        }
-        #endregion
-
         public FluentDialog(bool aero)
+            : base()
         {
             InitializeComponent();
 
             _viewModel = new FluentDialogViewModel(this, aero);
             DataContext = _viewModel;
-            Title = App.Settings.Prop.BootstrapperTitle;
-            Icon = App.Settings.Prop.BootstrapperIcon.GetIcon().GetImageSource();
 
             // setting this to true for mica results in the window being undraggable
             if (aero)
                 AllowsTransparency = true;
         }
-
-        private void UiWindow_Closing(object sender, CancelEventArgs e)
-        {
-            if (!_isClosing)
-                Bootstrapper?.Cancel();
-        }
-
-        #region IBootstrapperDialog Methods
-        public void ShowBootstrapper() => this.ShowDialog();
-
-        public void CloseBootstrapper()
-        {
-            _isClosing = true;
-            Dispatcher.BeginInvoke(this.Close);
-        }
-
-        public void ShowSuccess(string message, Action? callback) => BaseFunctions.ShowSuccess(message, callback);
-        #endregion
     }
 }

--- a/Bloxstrap/UI/Utility/TaskbarProgress.cs
+++ b/Bloxstrap/UI/Utility/TaskbarProgress.cs
@@ -57,7 +57,12 @@ namespace Bloxstrap.UI.Utility
         {
         }
 
-        private static Lazy<ITaskbarList3> _taskbarInstance = new Lazy<ITaskbarList3>(() => (ITaskbarList3)new TaskbarInstance());
+        private static Lazy<ITaskbarList3?> _taskbarInstance = new Lazy<ITaskbarList3?>(() =>
+        {
+            ITaskbarList3 taskbar = (ITaskbarList3)new TaskbarInstance();
+            bool hasInitialised = taskbar.HrInit() == 0; // reduce pointless calls by checking if we initialised properly
+            return hasInitialised ? taskbar : null;
+        });
 
         private static TaskbarStates ConvertEnum(TaskbarItemProgressState state)
         {
@@ -74,7 +79,12 @@ namespace Bloxstrap.UI.Utility
 
         private static int SetProgressState(IntPtr windowHandle, TaskbarStates taskbarState)
         {
-            return _taskbarInstance.Value.SetProgressState(windowHandle, taskbarState);
+            return _taskbarInstance.Value?.SetProgressState(windowHandle, taskbarState) ?? 1;
+        }
+
+        public static int SetProgressValue(IntPtr windowHandle, int progressValue, int progressMax)
+        {
+            return _taskbarInstance.Value?.SetProgressValue(windowHandle, (ulong)progressValue, (ulong)progressMax) ?? 1;
         }
 
         public static int SetProgressState(IntPtr windowHandle, TaskbarItemProgressState taskbarState)
@@ -82,9 +92,20 @@ namespace Bloxstrap.UI.Utility
             return SetProgressState(windowHandle, ConvertEnum(taskbarState));
         }
 
-        public static int SetProgressValue(IntPtr windowHandle, int progressValue, int progressMax)
+        /// <summary>
+        /// Will assume windowHandle is Process.GetCurrentProcess().MainWindowHandle
+        /// </summary>
+        public static int SetProgressState(TaskbarItemProgressState taskbarState)
         {
-            return _taskbarInstance.Value.SetProgressValue(windowHandle, (ulong)progressValue, (ulong)progressMax);
+            return SetProgressState(Process.GetCurrentProcess().MainWindowHandle, ConvertEnum(taskbarState));
+        }
+
+        /// <summary>
+        /// Will assume windowHandle is Process.GetCurrentProcess().MainWindowHandle
+        /// </summary>
+        public static int SetProgressValue(int progressValue, int progressMax)
+        {
+            return SetProgressValue(Process.GetCurrentProcess().MainWindowHandle, progressValue, progressMax);
         }
     }
 }

--- a/Bloxstrap/UI/ViewModels/Editor/BootstrapperEditorWindowViewModel.cs
+++ b/Bloxstrap/UI/ViewModels/Editor/BootstrapperEditorWindowViewModel.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
+using System.Windows.Shell;
 
 namespace Bloxstrap.UI.ViewModels.Editor
 {
@@ -42,6 +43,7 @@ namespace Bloxstrap.UI.ViewModels.Editor
                 _dialog = dialog;
 
                 dialog.Message = Strings.Bootstrapper_StylePreview_TextCancel;
+                dialog.TaskbarProgressState = TaskbarItemProgressState.Indeterminate;
                 dialog.CancelEnabled = true;
                 dialog.ShowBootstrapper();
             }

--- a/Bloxstrap/UI/ViewModels/Settings/AppearanceViewModel.cs
+++ b/Bloxstrap/UI/ViewModels/Settings/AppearanceViewModel.cs
@@ -11,6 +11,7 @@ using Microsoft.Win32;
 using Bloxstrap.UI.Elements.Settings;
 using Bloxstrap.UI.Elements.Editor;
 using Bloxstrap.UI.Elements.Dialogs;
+using System.Windows.Shell;
 
 namespace Bloxstrap.UI.ViewModels.Settings
 {
@@ -37,6 +38,7 @@ namespace Bloxstrap.UI.ViewModels.Settings
                 dialog.Message = Strings.Bootstrapper_StylePreview_TextCancel;
 
             dialog.CancelEnabled = true;
+            dialog.TaskbarProgressState = TaskbarItemProgressState.Indeterminate;
             dialog.ShowBootstrapper();
         }
 


### PR DESCRIPTION
- Cleaned up code involved with all WPF dialogs
- Made all WPF dialogs use TaskbarProgress instead of the TaskbarItemInfo element
- Reduced number of calls to the ITaskbarList3 interface if it fails to initialise
- Fixed WinForms dialog not resetting their taskbar state and progress after exiting preview mode
- Use `Indeterminate` taskbar state for preview mode