### PR TITLE
Always use `common` when downloading channels from setup bucket

### DIFF
--- a/Bloxstrap/RobloxInterfaces/Deployment.cs
+++ b/Bloxstrap/RobloxInterfaces/Deployment.cs
@@ -119,16 +119,7 @@
             string location = BaseUrl;
 
             if (!IsDefaultChannel)
-            {
-                string channelName;
-
-                if (ApplicationSettings.GetSettings(nameof(ApplicationSettings.PCClientBootstrapper), Channel).Get<bool>("FFlagReplaceChannelNameForDownload"))
-                    channelName = "common";
-                else
-                    channelName = Channel.ToLowerInvariant();
-
-                location += $"/channel/{channelName}";
-            }
+                location += "/channel/common";
 
             location += resource;
 


### PR DESCRIPTION
Roblox removed "FFlagReplaceChannelNameForDownload"