### PR TITLE
Windows Backdrop for Bootstrapper Styles

### DIFF
--- a/Bloxstrap/Resources/CustomBootstrapperSchema.json
+++ b/Bloxstrap/Resources/CustomBootstrapperSchema.json
@@ -46,7 +46,8 @@
 				"Theme": "Theme",
 				"Title": "string",
 				"IgnoreTitleBarInset": "bool",
-				"WindowCornerPreference": "WindowCornerPreference"
+				"WindowCornerPreference": "WindowCornerPreference",
+				"WindowsBackdrop": "WindowsBackdrop"
 			}
 		},
 		"TitleBar": {
@@ -355,6 +356,14 @@
 				"Default",
 				"Dark",
 				"Light"
+			]
+		},
+		"WindowsBackdrop": {
+			"Values": [
+				"Mica",
+				"Aero",
+				"Acrylic",
+				"None"
 			]
 		},
 		"FontWeight": {

--- a/Bloxstrap/Resources/CustomBootstrapperTemplate_Simple.xml
+++ b/Bloxstrap/Resources/CustomBootstrapperTemplate_Simple.xml
@@ -1,4 +1,4 @@
-﻿<BloxstrapCustomBootstrapper Version="1" Height="320" Width="520" IgnoreTitleBarInset="True" Theme="Default" Margin="30">
+﻿<BloxstrapCustomBootstrapper Version="1" Height="320" Width="520" IgnoreTitleBarInset="True" WindowsBackdrop="Aero" Theme="Default" Margin="30">
 	<!-- {0} -->
 	<TitleBar Title="" ShowMinimize="False" ShowClose="False" />
 

--- a/Bloxstrap/UI/Elements/Bootstrapper/CustomDialog.Elements.cs
+++ b/Bloxstrap/UI/Elements/Bootstrapper/CustomDialog.Elements.cs
@@ -410,6 +410,26 @@ namespace Bloxstrap.UI.Elements.Bootstrapper
                 Grid.SetRowSpan(dialog.ElementGrid, 2);
             }
 
+            string windowsbackdrop = xmlElement.Attribute("WindowsBackdrop")?.Value ?? "None";
+
+            switch (windowsbackdrop.ToLower())
+            {
+                case "aero":
+                    dialog.WindowBackdropType = Wpf.Ui.Appearance.BackgroundType.Aero;
+                    break;
+                case "acrylic":
+                    dialog.WindowBackdropType = Wpf.Ui.Appearance.BackgroundType.Acrylic;
+                    break;
+                case "mica":
+                    dialog.WindowBackdropType = Wpf.Ui.Appearance.BackgroundType.Mica;
+                    break;
+                case "none":
+                default:
+                    dialog.WindowBackdropType = Wpf.Ui.Appearance.BackgroundType.None;
+                    break;
+            }
+
+
             return new DummyFrameworkElement();
         }
 

--- a/Bloxstrap/UI/Elements/Bootstrapper/CustomDialog.xaml
+++ b/Bloxstrap/UI/Elements/Bootstrapper/CustomDialog.xaml
@@ -17,7 +17,9 @@
     Background="{ui:ThemeResource ApplicationBackgroundBrush}"
     ExtendsContentIntoTitleBar="True"
     ResizeMode="NoResize"
-    WindowBackdropType="Disable"
+    AllowsTransparency="True"
+    WindowBackdropType="None"
+    WindowStyle="None"
     WindowStartupLocation="CenterScreen"
     mc:Ignorable="d">
     <Window.TaskbarItemInfo>


### PR DESCRIPTION
Allows you to change the Windows backdrop on custom bootstrapper styles


<img width="1000" height="500" alt="image" src="https://github.com/user-attachments/assets/c32ab189-44cc-49bb-9d3c-d0dbd1b4c6f3" />
<img width="1000" height="500" alt="image" src="https://github.com/user-attachments/assets/0e56777b-1ef3-450b-946d-38e5095e1af9" />
